### PR TITLE
Made Eclipse-friendly if using ant rather than maven magic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea/
 *.iml
 /target/
+/bin/
 /lib

--- a/build.xml
+++ b/build.xml
@@ -7,6 +7,7 @@
     <property name="gherkin.version" value="2.12.2"/>
     <property name="cucumber-html.version" value="0.2.3"/>
     <property name="junit.version" value="4.12"/>
+    <property name="hamcrest.version" value="1.3"/>
     <property name="jars" value="lib"/>
 
     <target name="download">
@@ -25,6 +26,8 @@
              dest="${jars}/cucumber-html-${cucumber-html.version}.jar"/>
         <get src="${repo}/junit/junit/${junit.version}/junit-${junit.version}.jar"
              dest="${jars}/junit-${junit.version}.jar"/>
+        <get src="${repo}/org/hamcrest/hamcrest-all/${hamcrest.version}/hamcrest-all-${hamcrest.version}.jar"
+             dest="${jars}/hamcrest-all-${hamcrest.version}.jar"/>
     </target>
 
     <target name="classpath">


### PR DESCRIPTION
If you use 'ant download' to get the jar files and import into eclipse without the Maven magic, there is no hamcrest jar.
