### PR TITLE
Removed the hard coupling to Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,6 @@
     <name>Cucumber-Java Skeleton</name>
 
     <properties>
-        <java.version>1.7</java.version>
         <junit.version>4.12</junit.version>
         <cucumber.version>1.2.4</cucumber.version>
         <maven.compiler.version>3.3</maven.compiler.version>
@@ -46,8 +45,6 @@
                 <version>${maven.compiler.version}</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
                     <compilerArgument>-Werror</compilerArgument>
                 </configuration>
             </plugin>


### PR DESCRIPTION
The Maven build required Java 7. I suggest that this requirement is removed since Java 7 is end of life. Not requiring any Java version makes it easier to use Java 8 features in the code you create based on this skeleton.
