### PR TITLE
Update Cucumber version to 6.0.0 and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,44 +50,41 @@ Sometimes it can be useful to override these options without changing or recompi
 
 Using Maven:
 
-    mvn -Dcucumber.options="..." test
+    mvn -Dcucumber.features="..." -Dcucumber.glue="..." test
 
 Using Gradle:
 
-    gradlew -Dcucumber.options="..." test
+    gradlew -Dcucumber.features="..." -Dcucumber.glue="..." test
 
-Let's look at some things you can do with `cucumber.options`. Try this:
+For available options and overriding rules, please consult the following Maven command:
 
-    -Dcucumber.options="--help"
-
-That should list all the available options.
-
-*IMPORTANT*
-
-When you override options with `-Dcucumber.options`, you will completely override whatever options are hard-coded in
-your `@CucumberOptions` or in the script calling `cucumber.api.cli.Main`. There is one exception to this rule, and that
-is the `--plugin` option. This will not _override_, but _add_ a plugin. The reason for this is to make it easier
-for 3rd party tools to automatically configure additional plugins by appending arguments to a `cucumber.properties`
-file.
+    mvn exec:java \
+      -Dexec.classpathScope=test \
+      -Dexec.mainClass=io.cucumber.core.cli.Main \
+      -Dexec.args="--help"
 
 ### Run a subset of Features or Scenarios
 
-Specify a particular scenario by *line* (and use the pretty plugin, which prints the scenario back)
+Specify a particular scenario by *line*
 
-    -Dcucumber.options="classpath:skeleton/belly.feature:4 --plugin pretty"
+    -Dcucumber.features="classpath:skeleton/belly.feature:4"
 
 This works because Maven puts `./src/test/resources` on your `classpath`.
 You can also specify files to run by filesystem path:
 
-    -Dcucumber.options="src/test/resources/skeleton/belly.feature:4 --plugin pretty"
+    -Dcucumber.features="src/test/resources/skeleton/belly.feature:4"
+
+In case you have many feature files or scenarios to run against, separate them with commas `,`
+
+    -Dcucumber.features="src/test/resources/skeleton/belly.feature:4, src/test/resources/skeleton/stomach.feature"
 
 You can also specify what to run by *tag*:
 
-    -Dcucumber.options="--tags @bar --plugin pretty"
+    -Dcucumber.filter.tags="--tags @bar"
 
 ### Running only the scenarios that failed in the previous run
 
-    -Dcucumber.options="@target/rerun.txt"
+    -Dcucumber.features="@target/rerun.txt"
 
 This works as long as you have the `rerun` formatter enabled.
 
@@ -95,4 +92,4 @@ This works as long as you have the `rerun` formatter enabled.
 
 For example a JUnit formatter:
 
-    -Dcucumber.options="--plugin junit:target/cucumber-junit-report.xml"
+    -Dcucumber.plugin="junit:target/cucumber-junit-report.xml"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 project.ext {
-    cucumberVersion = '5.6.0'
+    cucumberVersion = '6.0.0'
 }
 
 dependencies {

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <junit.version>4.13</junit.version>
-        <cucumber.version>5.6.0</cucumber.version>
+        <cucumber.version>6.0.0</cucumber.version>
         <maven.compiler.version>3.8.1</maven.compiler.version>
         <maven.surefire.version>2.22.1</maven.surefire.version>
     </properties>


### PR DESCRIPTION
This PR intends to:
- Upgrade Cucumber dependency version to v6.0.0
- Update README.md to correctly instruct option overriding