### PR TITLE
Replace JUnit Jupiter with AssertJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Cucumber-Java Skeleton
 
-This is the simplest possible build script setup for Cucumber using Java.
-There is nothing fancy like a webapp or browser testing. All this does is to show
-you how to install and run Cucumber!
+This is the simplest possible setup for Cucumber using Java. There is nothing
+fancy like a webapp or browser testing. All this does is to show you how to
+set up and run Cucumber!
 
 There is a single feature file with one scenario. The scenario has three steps,
 two of them pending. See if you can make them all pass!
+
+To write assertions the project comes with [AssertJ](https://assertj.github.io/doc/#assertj-core-assertions-guide)
+included. 
 
 ## Get the code
 
@@ -21,7 +24,8 @@ Subversion:
 
 Or [download a zip](https://github.com/cucumber/cucumber-java-skeleton/archive/main.zip) file.
 
-## Use Maven
+## Run the tests
+### Use Maven
 
 Open a command window and run:
 
@@ -31,7 +35,7 @@ Open a command window and run:
 This runs Cucumber features using Cucumber's JUnit Platform Engine. The `Suite`
 annotation on the `RunCucumberTest` class tells JUnit to kick off Cucumber.
 
-## Use Gradle
+### Use Gradle
 
 Open a command window and run:
 
@@ -50,7 +54,7 @@ annotation on your test.
 
 For available parameters see: `io.cucumber.junit.platform.engine.Constants`
 
-### Run a subset of Features or Scenarios
+## Run a subset of Features or Scenarios
 
 Specify a particular scenario by *line*
 
@@ -59,11 +63,24 @@ Specify a particular scenario by *line*
 In case you have multiple feature files or scenarios to run against repeat the
 annotation.
 
-You can also specify what to run by *tag*:
+You can also specify what to run by *tag*. 
 
-    @IncludeTags("zucchini")
+First add a tag to a scenario:
 
-When using Maven, tags can be provided from the CLI using the `groups` and `excludedGroups` parameters. These take a
+```feature
+Feature: Belly
+
+  @Zucchini
+  Scenario: a few cukes
+```
+
+Then add an annotation to `RunCucumberTest`.
+
+```java
+@IncludeTags("Zucchini")
+```
+
+When using Maven, tags can be selected from the CLI using the `groups` and `excludedGroups` parameters. These take a
 [JUnit5 Tag Expression](https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions). 
 Note: When using JUnit, the `@` is not part of the tag.
 
@@ -71,14 +88,14 @@ Note: When using JUnit, the `@` is not part of the tag.
 mvn verify -DexcludedGroups="Haricots" -Dgroups="Zucchini | Gherkin"
 ```
 
-## Running a single scenario or feature
+### Running a single scenario or feature
 
 Maven and Gradle do not (yet) support selecting single features or scenarios
 with JUnit selectors. As a work around the `cucumber.features` property can be
 used. Because this property will cause Cucumber to ignore any other selectors
 from JUnit it is prudent to only execute the Cucumber engine.
 
-### With Maven
+#### With Maven
 
 To select the scenario on line 3 of the `belly.feature` file use:
 
@@ -88,6 +105,6 @@ To select the scenario on line 3 of the `belly.feature` file use:
 
 Note: Add `-Dcucumber.plugin=pretty` to get a more detailed output during test execution.
 
-### With Gradle
+#### With Gradle
 
 TODO: (I don't know how to do this. Feel free to send a pull request. ;))

--- a/gradle/build.gradle.kts
+++ b/gradle/build.gradle.kts
@@ -4,15 +4,15 @@ plugins {
 dependencies {
     testImplementation(platform("org.junit:junit-bom:5.11.4"))
     testImplementation(platform("io.cucumber:cucumber-bom:7.20.1"))
+    testImplementation(platform("org.assertj:assertj-bom:3.25.3"))
 
     testImplementation("io.cucumber:cucumber-java")
     testImplementation("io.cucumber:cucumber-junit-platform-engine")
     testImplementation("org.junit.platform:junit-platform-suite")
-    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.assertj:assertj-core")
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
 }
 

--- a/gradle/src/test/java/io/cucumber/skeleton/StepDefinitions.java
+++ b/gradle/src/test/java/io/cucumber/skeleton/StepDefinitions.java
@@ -1,6 +1,7 @@
 package io.cucumber.skeleton;
 
 import io.cucumber.java.en.Given;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StepDefinitions {
     @Given("I have {int} cukes in my belly")

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -29,6 +29,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-bom</artifactId>
+                <version>3.25.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -52,11 +59,10 @@
         </dependency>
 
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/maven/src/test/java/io/cucumber/skeleton/StepDefinitions.java
+++ b/maven/src/test/java/io/cucumber/skeleton/StepDefinitions.java
@@ -1,6 +1,7 @@
 package io.cucumber.skeleton;
 
 import io.cucumber.java.en.Given;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StepDefinitions {
     @Given("I have {int} cukes in my belly")


### PR DESCRIPTION
### ⚡️ What's your motivation? 

As a JUnit Platform Engine, Cucumber does not need JUnit Jupiter. It was included as a dependency to allow users to use Assertions. This is better done with AssertJ.

### 🏷️ What kind of change is this?
- :book: Documentation (improvements without changing code)

To be merged after https://github.com/cucumber/cucumber-jvm/pull/2969 is released.
