### PR TITLE
Improve README onboarding and enable pretty plugin by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,36 @@ Or [download a zip](https://github.com/cucumber/cucumber-jvm-starter-maven-java/
 
 Open a command window and run:
 
-    ./mvnw test
+On macOS/Linux:
+
+```shell
+./mvnw test
+```
+
+On Windows PowerShell:
+
+```powershell
+.\mvnw.cmd test
+```
 
 This runs Cucumber features using Cucumber's JUnit Platform Engine. The `Suite`
 annotation on the `RunCucumberTest` class tells JUnit to kick off Cucumber.
+
+Example output:
+
+```text
+Scenario: a few cukes
+
+  Given I have 42 cukes in my belly
+  When I wait 1 hour
+  Then my belly should growl
+
+org.opentest4j.TestAbortedException: TODO
+```
+
+The `When` step intentionally aborts with `TODO`. This is expected and part of
+the exercise. Complete the step definition and rerun the tests until all steps
+pass.
 
 ## Configuration 
 
@@ -84,4 +110,5 @@ To select the scenario on line 3 of the `belly.feature` file use:
 ./mvnw test -Dsurefire.includeJUnit5Engines=cucumber -Dcucumber.features=src/test/resources/com/example/project/belly.feature:3 
 ```
 
-Note: Add `-Dcucumber.plugin=pretty` to get a more detailed output during test execution.
+The starter project enables the `pretty` plugin by default. Running the tests
+displays the executed steps in the console while also generating the HTML report.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 This is the simplest possible setup for Cucumber-JVM using Java with Maven.
 There is nothing fancy like a webapp or browser testing. All this does is to
-show you how to set up and run Cucumber!
-
-There is a single feature file with one scenario. The scenario has three steps,
-one passing, skipped and undefined. See if you can make them all pass!
+show you how to set up and run Cucumber! If this is your first time using
+Cucumber have a look at the [10-minute tutorial](https://cucumber.io/docs/guides/10-minute-tutorial)
+first. 
 
 To write assertions the project comes with [AssertJ](https://assertj.github.io/doc/#assertj-core-assertions-guide)
-included. 
+included.
 
 ## Get the code
 
@@ -38,21 +37,21 @@ On Windows PowerShell:
 This runs Cucumber features using Cucumber's JUnit Platform Engine. The `Suite`
 annotation on the `RunCucumberTest` class tells JUnit to kick off Cucumber.
 
-Example output:
-
 ```text
-Scenario: a few cukes
+[INFO] Running com.example.project.RunCucumberTest
 
-  Given I have 42 cukes in my belly
-  When I wait 1 hour
-  Then my belly should growl
-
-org.opentest4j.TestAbortedException: TODO
+Scenario: a few cukes                 # classpath:com/example/project/belly.feature:3
+  ✔ Given I have 42 cukes in my belly # com.example.project.StepDefinitions.I_have_cukes_in_my_belly(int)
+  ↷ When I wait 1 hour                # com.example.project.StepDefinitions.i_wait_hour(java.lang.Integer)
+        org.opentest4j.TestAbortedException: TODO: Implement me
+                at com.example.project.StepDefinitions.i_wait_hour(StepDefinitions.java:19)
+                at ✽.I wait 1 hour(classpath:com/example/project/belly.feature:5)
+  ↷ Then my belly should growl
 ```
 
-The `When` step intentionally aborts with `TODO`. This is expected and part of
-the exercise. Complete the step definition and rerun the tests until all steps
-pass.
+The output show that there is a single feature file with one scenario. The
+scenario has three steps, one passing, one pending, and one undefined. See if
+you make can each step pass.
 
 ## Configuration 
 
@@ -110,5 +109,5 @@ To select the scenario on line 3 of the `belly.feature` file use:
 ./mvnw test -Dsurefire.includeJUnit5Engines=cucumber -Dcucumber.features=src/test/resources/com/example/project/belly.feature:3 
 ```
 
-The starter project enables the `pretty` plugin by default. Running the tests
-displays the executed steps in the console while also generating the HTML report.
+Note: Add `-Dcucumber.plugin=pretty` to get a more detailed output during test
+execution.

--- a/src/test/java/com/example/project/RunCucumberTest.java
+++ b/src/test/java/com/example/project/RunCucumberTest.java
@@ -11,7 +11,10 @@ import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 @Suite
 @IncludeEngines("cucumber")
 @SelectPackages("com.example.project")
-@ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "html:target/report.html")
+@ConfigurationParameter(
+        key = PLUGIN_PROPERTY_NAME,
+        value = "pretty,html:target/report.html"
+)
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "com.example.project")
 public class RunCucumberTest {
 }

--- a/src/test/java/com/example/project/RunCucumberTest.java
+++ b/src/test/java/com/example/project/RunCucumberTest.java
@@ -1,20 +1,13 @@
 package com.example.project;
 
-import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParametersResource;
 import org.junit.platform.suite.api.IncludeEngines;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
-import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
-import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
-
 @Suite
 @IncludeEngines("cucumber")
 @SelectPackages("com.example.project")
-@ConfigurationParameter(
-        key = PLUGIN_PROPERTY_NAME,
-        value = "pretty,html:target/report.html"
-)
-@ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "com.example.project")
+@ConfigurationParametersResource("cucumber.properties")
 public class RunCucumberTest {
 }

--- a/src/test/java/com/example/project/StepDefinitions.java
+++ b/src/test/java/com/example/project/StepDefinitions.java
@@ -13,10 +13,10 @@ public class StepDefinitions {
         belly.eat(cukes);
     }
 
-    @When("I wait {int} hour")
+    @When("I wait {int} seconds")
     public void i_wait_hour(Integer int1) {
         // Write code here that turns the phrase above into concrete actions
-        throw new TestAbortedException("TODO");
+        throw new TestAbortedException("TODO: Implement me");
     }
 
 }

--- a/src/test/resources/com/example/project/belly.feature
+++ b/src/test/resources/com/example/project/belly.feature
@@ -2,5 +2,5 @@ Feature: Belly
 
   Scenario: a few cukes
     Given I have 42 cukes in my belly
-    When I wait 1 hour
+    When I wait 10 seconds
     Then my belly should growl

--- a/src/test/resources/cucumber.properties
+++ b/src/test/resources/cucumber.properties
@@ -1,0 +1,2 @@
+cucumber.glue=com.example.project
+cucumber.plugin=pretty, html:target/report.html


### PR DESCRIPTION
## 🤔 What's changed?

- Added separate instructions for running the Maven wrapper on macOS/Linux and Windows PowerShell.
- Enabled the `pretty` plugin by default in `RunCucumberTest`.
- Added an example of the console output produced by the `pretty` plugin.
- Documented that the `TODO` step is intentional and part of the exercise.

## ⚡ What's your motivation?

This PR addresses the feedback in #104 to improve the onboarding experience for first-time users.

While testing the project on Windows, I noticed that:
- PowerShell users need to run `.\mvnw.cmd test`.
- The expected console output wasn't shown in the README.
- It wasn't immediately obvious that the `TODO` step is intentional.

These changes make the getting-started experience clearer while keeping the project behavior unchanged.

Closes #104